### PR TITLE
Fix out of bounds panic with empty separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ assert_eq!(slugify!("hello world"), "hello-world");
  ```rust
  assert_eq!(slugify!("hello world", separator = "."), "hello.world");
  assert_eq!(slugify!("hello world", separator = " "), "hello world");
+ assert_eq!(slugify!("hello world", separator = ""), "helloworld");
  ```
  
 ## Stop words filtering

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 //! # fn main() {
 //!assert_eq!(slugify!("hello world", separator = "."), "hello.world");
 //!assert_eq!(slugify!("hello world", separator = " "), "hello world");
+//!assert_eq!(slugify!("hello world", separator = ""), "helloworld");
 //! # }
 //! ```
 //! 
@@ -164,7 +165,12 @@ pub fn slugify(string: &str, stop_words: &str, sep: &str, max_length: Option<usi
     let mut string: String = unidecode(string.into())
         .to_lowercase()
         .trim()
-        .trim_matches(char_vec[0])
+        // guard against an empty char
+        // None result is redundant with .trim() but is nondestructive/safe
+        .trim_matches(match char_vec.get(0) {
+            Some(a) => a.to_owned(),
+            None => ' ',
+        })
         .replace(' ', &sep.to_string());
 
     // remove stop words
@@ -195,7 +201,7 @@ pub fn slugify(string: &str, stop_words: &str, sep: &str, max_length: Option<usi
         }
     }
 
-    if slug.last() == Some(&(char_vec[0] as u8)) {
+    if char_vec.len() > 0 && slug.last() == Some(&(char_vec[0] as u8)) {
         slug.pop();
     }
 


### PR DESCRIPTION
Thanks a ton for this crate!

If one uses `slugify!("hello world", separator = "")` this will lead to a panic. My use case was part of a process to reduce a given HTML form element label down to a string that would be compliant for use in the `name` attribute of an HTML form -- generally all letters, no spaces. I was trying to be clever by seeking a slug library, and using an empty separator. In the end I still used the slugify, then replaced all the slugs with empty strings, but I figured I'd go back a recontribute a fix since this does cause a panic.

```
stderr:
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', src/lib.rs:168:23
```

I added a test, updated docs to reflect that this usage now works.